### PR TITLE
Release 0.2.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Python utility functions for slices.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/kenjutsu-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/kenjutsu-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/kenjutsu-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/kenjutsu-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/kenjutsu-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/kenjutsu-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/kenjutsu/badges/version.svg)](https://anaconda.org/conda-forge/kenjutsu)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/kenjutsu/badges/downloads.svg)](https://anaconda.org/conda-forge/kenjutsu)
+
 Installing kenjutsu
 ===================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `kenjutsu` available on your platf
 ```
 conda search kenjutsu --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/kenjutsu-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/kenjutsu-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/kenjutsu-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/kenjutsu-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/kenjutsu-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/kenjutsu-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/kenjutsu/badges/version.svg)](https://anaconda.org/conda-forge/kenjutsu)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/kenjutsu/badges/downloads.svg)](https://anaconda.org/conda-forge/kenjutsu)
 
 
 Updating kenjutsu-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,27 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +57,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "kenjutsu" %}
-{% set version = "0.1.0" %}
-{% set sha256 = "be95a38e2af06c64091961114217a814ce861018b9d4e76f5e3c971cd3fcd658" %}
+{% set version = "0.2.0" %}
+{% set sha256 = "808d8653f66cc09db518a9d7b751a3545a8617aafd1eb0abdca8bd40697793b6" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```markdown
v0.2.0

* Upgrade versioneer to 0.17. #6
* Preserve arguments to `reformat_slices`. #8
* Move bulk of doctests to the test suite. #9
* Drop unused code. #10 , #13
* Full test coverage of `reformat_slices`. #11
* Python compatibility code cleanup. #14
* Total rewrite of `reformat_slice`. #15
* Fix out-of-bound checks in `reformat_slice`. #16
* Guard against `None` comparisons in `reformat_slice`. #17 , #18
* Add more unit tests for `len_slice`. #19 , #26
* Support inverted slices with `len_slice`. #20
* Full test coverage. #12
* Total rewrite of test suite. #21 , #23
* Convert assertions to exceptions. #25
* Handle `Ellipsis`. #7 , #31
* Preserve arguments to `reformat_slices`. #27 , #28 , #29
* Handle empty tuple. #30
* Optimize test suite. #32
* Preserve test suite parameters. #33
* Formatting tweaks. #34
* Handle more/improve empty slices. #35 , #36
* Handle integer index. #22
```

Note: Also re-rendered with `conda-smithy` version `1.6.1`.