### PR TITLE
Release 0.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "kenjutsu" %}
-{% set version = "0.4.2" %}
-{% set sha256 = "2b5a68253e6055283c30ee5a9c47d5710e3933875e11389e7687d1965405db1a" %}
+{% set version = "0.5.0" %}
+{% set sha256 = "aa41865ef95709cd8d60193f1823a6aa647bb794237453b4aaf84d402ab513ea" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```markdown
### v0.5.0

* Assertions about shapes for `split_blocks`. #64
* Add optional index flag to `split_blocks`. #62
  * Deprecate current behavior of having no index.
  * Warn that flag will be dropped in the long run.
* Add `num_blocks`. #63
```