### PR TITLE
Release 0.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,8 +24,14 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
+
   imports:
     - kenjutsu
+
+  commands:
+    - python -m unittest discover -s .
 
 about:
   home: https://github.com/jakirkham/kenjutsu

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "kenjutsu" %}
-{% set version = "0.5.0" %}
-{% set sha256 = "aa41865ef95709cd8d60193f1823a6aa647bb794237453b4aaf84d402ab513ea" %}
+{% set version = "0.5.1" %}
+{% set sha256 = "0d88ffeaa036ab4c6c9e20979c01e59a498b75446bfffeed5386f2474699f08b" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
```markdown
### v0.5.1

* Add 2017 to the license copyright. #65
* Update versioneer to 0.18. #66
* Cleanup MANIFEST.in whitespace. #67
* Add conda-forge badge. #68
* Recut with cookiecutter. #69
* Update copyright years in docs. #70
```